### PR TITLE
Fix auth key format, Go cleanups

### DIFF
--- a/send/main.go
+++ b/send/main.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"time"
 
@@ -11,7 +12,7 @@ import (
 )
 
 var url = "https://<your-subdomain>.hosted-metrics.grafana.net/metrics"
-var apiKey = "<your api key from grafana.net -- should be editor role>"
+var apiKey = "<your user from grafana.net>:<your api key from grafana.net -- should be editor (or MetricsPublisher) role>"
 
 // createPoint creates a datapoint, i.e. a MetricData structure, and makes sure the id is set.
 func createPoint(name string, interval int, val float64, time int64) *schema.MetricData {
@@ -66,8 +67,11 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	buf := make([]byte, 4096)
-	n, err := resp.Body.Read(buf)
+	defer resp.Body.Close()
+	respData, err := io.ReadAll(resp.Body)
+	if err != nil {
+		panic(err)
+	}
 	fmt.Println(resp.StatusCode, resp.Status)
-	fmt.Println(string(buf[:n]))
+	fmt.Println(string(respData))
 }

--- a/send/main.py
+++ b/send/main.py
@@ -2,7 +2,7 @@ import requests
 from datetime import datetime, timedelta
 
 GRAFANA_URL = 'https://<your-subdomain>.hosted-metrics.grafana.net/metrics'
-GRAFANA_APIKEY = '<your user from grafana.net>:<your api key from grafana.net -- should be editor role>'
+GRAFANA_APIKEY = '<your user from grafana.net>:<your api key from grafana.net -- should be editor (or MetricsPublisher) role>'
 
 
 def write_metrics(metrics, url, apikey):

--- a/send/main.sh
+++ b/send/main.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-key="<api-key>"
+key="<user_id>:<api-key>"
 addr="https://<your-instance>.hosted-metrics.grafana.net"
 
 curl -X POST -H "Authorization: Bearer $key" -H "Content-Type: application/json" "$addr/metrics" -d '[{


### PR DESCRIPTION
I tried to push data to GF Cloud Graphite and spent enough time to figure out why I am getting an error like this:

```json
{"status":"error","error":"authentication error: legacy auth cannot be upgraded because the host is not found"}
```

The reason was that I have not prepended API key with `<USER_ID>:`.

Also, looks like `MetricsPublisher` role is enough to send.